### PR TITLE
Added process to shuffle channels older than 24 hours

### DIFF
--- a/server/plex_radio_api.py
+++ b/server/plex_radio_api.py
@@ -24,9 +24,10 @@ def generate_daily_playlists():
     """
     Generate daily playlists for each channel based on the current playlist.
     """
+    channel_playlists.clear()  # Clear existing playlists
+
     for channel in current_config.get_channels():
-        current_playlist = plex.playlist(channel['playlist'])
-        daily_playlist_instance = daily_playlist.DailyPlaylist(current_playlist)
+        daily_playlist_instance = daily_playlist.DailyPlaylist(plex, channel['playlist'])
         channel_playlists.append(daily_playlist_instance)
 
 def calculate_current_song_info(channel_number=0):
@@ -34,6 +35,10 @@ def calculate_current_song_info(channel_number=0):
     Calculate the current song that should be playing based on time of day
     and return its information including title, start time, and media link
     """
+    
+    # Added extra process to refresh the playlist if needed, this can cause initial slow load though
+    channel_playlists[channel_number].refresh_if_needed()
+    
     try:
         # Find the specified playlist
         target_playlist = channel_playlists[channel_number] if channel_number < len(channel_playlists) else None


### PR DESCRIPTION
- Moved full playlist generation logic to DailyPlaylist class
- Added method to verify if the playist is expired
- Added method to refresh playlist if it has expired
- Changed API logic to verify call refresh check per call

As part of this, API calls may take longer during initial refresh, but only a one time issue. The refresh process will get a new copy of the playlist from Plex, so if any new songs were added they will be picked up every 24 hours

This fully resolves #2 