### PR TITLE
Added playback options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A REST API that simulates radio channels by providing information about the curr
 
 - **Time-based playback simulation**: Calculates what song should be playing based on current time
 - **Multiple radio channels**: Support for multiple configured channels/playlists
-- **Daily playlist generation**: Creates shuffled 24-hour playlists for each channel
+- **Flexible playback modes**: Choose between sequential or shuffle playback for each channel
+- **Daily playlist generation**: Creates 24-hour playlists for each channel with configurable playback order
 - **Current and next song info**: Returns both current and upcoming track details
 - **YAML configuration**: Easy configuration of Plex server and channels
 - **Direct media links**: Provides direct URLs to media files for playback
@@ -67,7 +68,11 @@ Returns the current song information from a specific channel by number (0-based 
     }
   },
   "timestamp": "2025-08-25T10:30:00.123456",
-  "channel": "Jazz Radio"
+  "channel": {
+    "name": "Jazz Radio",
+    "playlist": "Jazz Radio",
+    "playback": "shuffle"
+  }
 }
 ```
 
@@ -81,11 +86,13 @@ Lists all configured radio channels.
   "data": [
     {
       "name": "Jazz Radio", 
-      "playlist": "Jazz Radio"
+      "playlist": "Jazz Radio",
+      "playback": "shuffle"
     },
     {
       "name": "Rock Radio",
-      "playlist": "Rock Radio"
+      "playlist": "Rock Radio",
+      "playback": "sequential"
     }
   ],
   "count": 2
@@ -138,8 +145,10 @@ Health check endpoint to verify API and Plex server connectivity.
    channels:
      - name: "Jazz Radio"
        playlist: "Your Jazz Playlist Name"
+       playback: "shuffle"  # Optional: "shuffle" (default) or "sequential"
      - name: "Rock Radio"
        playlist: "Your Rock Playlist Name"
+       playback: "sequential"  # Play songs in playlist order
    ```
 
 ## Configuration
@@ -162,9 +171,17 @@ plex:
 channels:
   - name: "Jazz Radio"                # Display name for the channel
     playlist: "Jazz Favorites"        # Exact name of your Plex playlist
+    playback: "shuffle"               # Optional: "shuffle" (default) or "sequential"
   - name: "Rock Radio"
     playlist: "Rock Classics"
+    playback: "sequential"            # Play songs in playlist order
+  - name: "Pop Radio"                 # playback field is optional
+    playlist: "Pop Hits"              # Defaults to "shuffle" if not specified
 ```
+
+### Playback Modes
+- **shuffle** (default): Songs are shuffled daily, creating a random order each day
+- **sequential**: Songs play in their original playlist order, allowing you to listen through albums or curated sequences
 
 ## Usage
 
@@ -238,7 +255,7 @@ curl http://localhost:5000/health
 
 The API simulates radio stations by:
 
-1. **Daily Playlist Generation**: At startup, it creates shuffled 24-hour playlists for each configured channel
+1. **Daily Playlist Generation**: At startup, it creates 24-hour playlists for each configured channel, either shuffled or in sequential order based on the `playback` setting
 2. **Time-based Calculation**: Uses current time of day (seconds since midnight) to determine position in the playlist
 3. **Song Position**: Calculates exactly where within a song playback should start
 4. **Seamless Playback**: Provides both current song and next song information for gapless transitions
@@ -333,7 +350,9 @@ The API includes comprehensive error handling for:
 
 - The configuration file `plex_radio_config.yaml` is gitignored for security
 - Use the `example_plex_radio_config.yaml` as a template
-- Each channel generates a new shuffled playlist daily at startup
+- Each channel generates a new playlist daily at startup (shuffled or sequential based on configuration)
 - Start times are calculated as seconds into the current song
 - The API runs in debug mode by default (disable for production)
 - Docker deployment automatically runs in production mode
+- Sequential playback preserves original playlist order, perfect for concept albums or DJ mixes
+- Shuffle mode provides variety while maintaining the radio experience

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ channels:
     playlist: "Rock Classics"
     playback: "sequential"            # Play songs in playlist order
   - name: "Pop Radio"                 # playback field is optional
-    playlist: "Pop Hits"              # Defaults to "shuffle" if not specified
+    playlist: "Pop Hits"              # Defaults to "shuffle" if playback not specified
 ```
 
 ### Playback Modes

--- a/server/config.py
+++ b/server/config.py
@@ -21,7 +21,7 @@ class Config:
         """Return default configuration if file doesn't exist"""
         return {
             'channels': [
-                {'name': 'Maisie Radio', 'playlist': 'Maisie Power House'}
+                {'name': 'Maisie Radio', 'playlist': 'Maisie Power House', 'playback': 'shuffle'}
             ]
         }
 
@@ -40,6 +40,57 @@ class Config:
                 return channel['playlist']
         return None
 
+    def get_playback_mode_for_channel(self, channel_name):
+        """Get playback mode for a specific channel (shuffle or sequential)"""
+        for channel in self.get_channels():
+            if channel['name'] == channel_name:
+                playback = channel.get('playback', 'shuffle')  # Default to shuffle
+                return self.validate_playback_mode(playback)
+        return 'shuffle'  # Default fallback
+
+    def validate_playback_mode(self, playback_mode):
+        """Validate and normalize playback mode"""
+        if playback_mode is None:
+            return 'shuffle'
+        
+        # Convert to lowercase and validate
+        playback_mode = str(playback_mode).lower().strip()
+        valid_modes = ['shuffle', 'sequential']
+        
+        if playback_mode in valid_modes:
+            return playback_mode
+        else:
+            print(f"Warning: Invalid playback mode '{playback_mode}'. Using default 'shuffle'. Valid options: {valid_modes}")
+            return 'shuffle'
+
+    def validate_all_channels(self):
+        """Validate all channels and their playback modes"""
+        channels = self.get_channels()
+        validated_channels = []
+        
+        for channel in channels:
+            # Validate required fields
+            if 'name' not in channel or 'playlist' not in channel:
+                print(f"Error: Channel missing required fields (name/playlist): {channel}")
+                continue
+            
+            # Validate and normalize playback mode
+            original_playback = channel.get('playback')
+            validated_playback = self.validate_playback_mode(original_playback)
+            
+            # Create validated channel
+            validated_channel = channel.copy()
+            validated_channel['playback'] = validated_playback
+            validated_channels.append(validated_channel)
+            
+            # Log if playback mode was corrected or defaulted
+            if original_playback is None:
+                print(f"Channel '{channel['name']}': Using default playback mode 'shuffle'")
+            elif original_playback != validated_playback:
+                print(f"Channel '{channel['name']}': Corrected playback mode from '{original_playback}' to '{validated_playback}'")
+        
+        return validated_channels
+
 # Usage example
 if __name__ == "__main__":
     config = Config('example.yaml')
@@ -48,8 +99,11 @@ if __name__ == "__main__":
     channels = config.get_channels()
     print("Available channels:")
     for channel in channels:
-        print(f"  - {channel['name']}: {channel['playlist']}")
+        playback_mode = channel.get('playback', 'shuffle')
+        print(f"  - {channel['name']}: {channel['playlist']} (playback: {playback_mode})")
     
-    # Get specific playlist
+    # Get specific playlist and playback mode
     playlist = config.get_playlist_for_channel("Maisie Radio")
+    playback_mode = config.get_playback_mode_for_channel("Maisie Radio")
     print(f"\nPlaylist for Maisie Radio: {playlist}")
+    print(f"Playback mode for Maisie Radio: {playback_mode}")

--- a/server/configuration/example_plex_radio_config.yaml
+++ b/server/configuration/example_plex_radio_config.yaml
@@ -5,5 +5,10 @@ plex:
 channels:
   - name: "Jazz Radio"
     playlist: "Jazz Radio"
+    playback: "shuffle"  # Explicitly set to shuffle
   - name: "Rock Radio"
     playlist: "Rock Radio"
+    playback: "sequential"  # Explicitly set to sequential
+  - name: "Pop Radio"
+    playlist: "Pop Radio"
+    # No playback specified - will default to shuffle

--- a/server/daily_playlist.py
+++ b/server/daily_playlist.py
@@ -3,21 +3,28 @@ import datetime
 import random
 
 class DailyPlaylist:
-    def __init__(self, plex, channel_playlist_name):
+    def __init__(self, plex, channel_playlist_name, playback_mode='shuffle'):
         self.plex = plex
         self.channel_playlist_name = channel_playlist_name
+        self.playback_mode = playback_mode  # 'shuffle' or 'sequential'
         self.current_playlist = None
         self.creation_time = datetime.datetime.now()
         self.playlist_items = None
         self.refresh_if_needed()
 
     def generate_playlist(self):
-        """Generate a shuffled playlist that is limited to 24 hours long"""
-        random.shuffle(self.current_playlist)
+        """Generate a playlist that is limited to 24 hours long, with optional shuffling"""
+        # Create a copy of the playlist to avoid modifying the original
+        playlist_copy = self.current_playlist.copy()
+        
+        # Apply shuffling based on playback mode
+        if self.playback_mode == 'shuffle':
+            random.shuffle(playlist_copy)
+        # For sequential mode, we keep the original order
 
         limited_playlist = []
         # Limit the playlist to 24 hours
-        for item in self.current_playlist:
+        for item in playlist_copy:
             total_duration = sum(item.duration for item in limited_playlist)
             if total_duration < 24 * 60 * 60 * 1000:  # 24 hours in milliseconds
                 limited_playlist.append(item)


### PR DESCRIPTION
Wanted to be able to allow playlist order to be preserved as an optional option.

I (copilot) implemented a property in the channel config of "playback" which allows for either shuffle or sequential. If nothing is provided it defaults to shuffle. Any other invalid option e.g. "random" will default to shuffle and throw a warning.  

API Responses also show the playback type for channel in the response.

README was updated to include this information.

I (copilot) did some testing of implementation and all passed.

I did however pull it down to my local machine and do a build and test and confirmed it actually works.